### PR TITLE
.bashrc: PS1: escape sequence

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -8,7 +8,7 @@ source ${HOME}/.commonshellrc
 # Check for an interactive session
 [ -z "$PS1" ] && return
 
-PS1='[\u@\e[0;31m\h\e[m \W]\[$(tput setaf 7)\] \j$ '
+PS1='[\u@\[\e\][0;31m\h\e[m \W]\[$(tput setaf 7)\] \j$ '
 PS1="$PS1"'$([ -n "$TMUX" ] && tmux setenv TMUXPWD_$(tmux display -p "#I_#P") "$PWD")'
 
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash


### PR DESCRIPTION
Bash is unable to determine exactly which parts of your prompt are
text and which are terminal codes. You have to help it by wrapping
invisible control codes in \[..\] (and ensuring that visible
characters are not wrapped in \[..\]).

More info: https://github.com/koalaman/shellcheck/wiki/SC2025